### PR TITLE
Install uniffi-bindgen-cs with the toolchain it pins

### DIFF
--- a/LoroCs/LoroCs/LoroCs.csproj
+++ b/LoroCs/LoroCs/LoroCs.csproj
@@ -47,6 +47,7 @@
     <PropertyGroup>
       <_UniffiBindgenGitUrl>https://github.com/NordSecurity/uniffi-bindgen-cs</_UniffiBindgenGitUrl>
       <_UniffiBindgenTag>v0.11.0+v0.31.0</_UniffiBindgenTag>
+      <_UniffiBindgenRustChannel>1.88</_UniffiBindgenRustChannel>
     </PropertyGroup>
 
     <!-- Windows: use PowerShell to inspect cargo install list output -->
@@ -61,7 +62,7 @@
 
     <Message Condition="'$(UniffiInstalled)' != '0'" Text="Installing uniffi-bindgen-cs as it appears not to be installed in the correct version yet" />
     <Message Condition="'$(UniffiInstalled)' == '0'" Text="uniffi-bindgen-cs is already installed in the correct version - no need to install" />
-    <Exec Condition="'$(UniffiInstalled)' != '0'" Command="cargo install --git $(_UniffiBindgenGitUrl) --tag $(_UniffiBindgenTag)" />
+    <Exec Condition="'$(UniffiInstalled)' != '0'" Command="cargo +$(_UniffiBindgenRustChannel) install --git $(_UniffiBindgenGitUrl) --tag $(_UniffiBindgenTag)" />
 
     <!-- Detect platform and architecture to select the correct native library for uniffi-bindgen-cs -->
     <PropertyGroup>


### PR DESCRIPTION
rustup resolves a toolchain from the directory `cargo install` is called in, not from the package being installed, so the bindgen currently builds with whatever the consumer's environment selects. In a repo that has its own `rust-toolchain.toml` that means the generator is built against an unrelated pin, and cargo 1.96+ warns about it:

```
warning: default toolchain implicitly overridden with `1.97.1-x86_64-pc-windows-msvc` by rustup toolchain file
  = help: use `cargo +stable install` if you meant to use the stable toolchain
  = note: rustup selects the toolchain based on the parent environment and not the environment of the package being installed
```

MSBuild's `Exec` re-logs warning-shaped output as a build warning, which is enough to trip a warning-count gate. We hit exactly that in a consuming build.

Naming the channel that `uniffi-bindgen-cs`'s own `rust-toolchain.toml` asks for at the pinned tag (1.88 for `v0.11.0+v0.31.0`) makes the generator build reproducible regardless of the caller, and silences the warning. It needs bumping alongside `_UniffiBindgenTag`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build process to use Rust toolchain version 1.88 when installing the required binding generator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->